### PR TITLE
add options to set custom namespace separator and a method name trans…

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,36 @@ if err := client.Call(); err != nil {
 }
 ```
 
+## Options
+
+### Using `WithMethodNameFormatter`
+
+```go
+func main() {
+	// create a new server instance with a custom separator
+	rpcServer := jsonrpc.NewServer(jsonrpc.WithMethodNameFormatter(
+		func(namespace, method string) string {
+			return namespace + "_" + method
+		}),
+	)
+
+	// create a handler instance and register it
+	serverHandler := &SimpleServerHandler{}
+	rpcServer.Register("SimpleServerHandler", serverHandler)
+
+	// serve the api
+	testServ := httptest.NewServer(rpcServer)
+	defer testServ.Close()
+
+	fmt.Println("URL: ", "ws://"+testServ.Listener.Addr().String())
+
+	// rpc method becomes SimpleServerHandler_AddGet
+
+    [..do other app stuff / wait..]
+}
+```
+
+
 ## Contribute
 
 PRs are welcome!

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/filecoin-project/go-jsonrpc
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/google/uuid v1.1.1

--- a/handler.go
+++ b/handler.go
@@ -77,6 +77,8 @@ type handler struct {
 
 	paramDecoders map[reflect.Type]ParamDecoder
 
+	methodNameFormatter MethodNameFormatter
+
 	tracer Tracer
 }
 
@@ -89,6 +91,8 @@ func makeHandler(sc ServerConfig) *handler {
 
 		aliasedMethods: map[string]string{},
 		paramDecoders:  sc.paramDecoders,
+
+		methodNameFormatter: sc.methodNameFormatter,
 
 		maxRequestSize: sc.maxRequestSize,
 
@@ -126,7 +130,7 @@ func (s *handler) register(namespace string, r interface{}) {
 
 		valOut, errOut, _ := processFuncOut(funcType)
 
-		s.methods[namespace+"."+method.Name] = methodHandler{
+		s.methods[s.methodNameFormatter(namespace, method.Name)] = methodHandler{
 			paramReceivers: recvs,
 			nParams:        ins,
 

--- a/options_server.go
+++ b/options_server.go
@@ -13,6 +13,8 @@ type jsonrpcReverseClient struct{ reflect.Type }
 
 type ParamDecoder func(ctx context.Context, json []byte) (reflect.Value, error)
 
+type MethodNameFormatter func(namespace, method string) string
+
 type ServerConfig struct {
 	maxRequestSize int64
 	pingInterval   time.Duration
@@ -22,6 +24,7 @@ type ServerConfig struct {
 
 	reverseClientBuilder func(context.Context, *wsConn) (context.Context, error)
 	tracer               Tracer
+	methodNameFormatter  MethodNameFormatter
 }
 
 type ServerOption func(c *ServerConfig)
@@ -32,6 +35,9 @@ func defaultServerConfig() ServerConfig {
 		maxRequestSize: DEFAULT_MAX_REQUEST_SIZE,
 
 		pingInterval: 5 * time.Second,
+		methodNameFormatter: func(namespace, method string) string {
+			return namespace + "." + method
+		},
 	}
 }
 
@@ -56,6 +62,12 @@ func WithServerErrors(es Errors) ServerOption {
 func WithServerPingInterval(d time.Duration) ServerOption {
 	return func(c *ServerConfig) {
 		c.pingInterval = d
+	}
+}
+
+func WithMethodNameFormatter(formatter MethodNameFormatter) ServerOption {
+	return func(c *ServerConfig) {
+		c.methodNameFormatter = formatter
 	}
 }
 


### PR DESCRIPTION
…former (#131)

Add a new option making it possible to customize JSON-RPC method names.